### PR TITLE
Calculate roic_1 and roic_3 from Yahoo Finance if possible + tests

### DIFF
--- a/src/RuleOneInvestingCalculations.py
+++ b/src/RuleOneInvestingCalculations.py
@@ -254,3 +254,10 @@ def calculate_margin_of_safety(sticker_price, margin_of_safety=0.5):
   if not sticker_price:
     return None
   return sticker_price * (1 - margin_of_safety)
+
+def calculate_roic(net_income, cash, long_term_debt, stockholder_equity):
+  return (
+    net_income
+    /
+    (stockholder_equity + long_term_debt - cash)
+  ) * 100

--- a/src/StockRow.py
+++ b/src/StockRow.py
@@ -97,7 +97,6 @@ class StockRowKeyStats:
       
       total_debts = _get_nested_values_for_key(data_dict, "Total Debt") # Already in USD millions
       self.calculate_total_debt(total_debts)
-
     except Exception as e:
       logging.error(traceback.format_exc())
       return False

--- a/src/YahooFinance.py
+++ b/src/YahooFinance.py
@@ -206,36 +206,14 @@ class YahooFinanceQuoteSummary:
           break
     return True
 
-  def _get_balance_sheet_history(self, position):
+  def get_balance_sheet_history(self, key):
     history = []
-    for stmt in self.module_data.get('balanceSheetHistory').get('balanceSheetStatements'):
-      history.append(stmt.get(position).get('raw'))
+    for stmt in self.module_data.get('balanceSheetHistory', {}).get('balanceSheetStatements', []):
+      history.append(stmt.get(key).get('raw'))
     return history
 
-  def _get_income_statement_history(self, position):
+  def get_income_statement_history(self, key):
     history = []
-    for stmt in self.module_data.get('incomeStatementHistory').get('incomeStatementHistory'):
-      history.append(stmt.get(position).get('raw'))
+    for stmt in self.module_data.get('incomeStatementHistory', {}).get('incomeStatementHistory', []):
+      history.append(stmt.get(key).get('raw'))
     return history
-
-  def _get_roic_history(self):
-    net_income_history = self._get_income_statement_history('netIncome')
-    cash_history = self._get_balance_sheet_history('cash')
-    long_term_debt_history = self._get_balance_sheet_history('longTermDebt')
-    stockholder_equity_history = self._get_balance_sheet_history('totalStockholderEquity')
-    roic_history = []
-    for i in range(0, len(net_income_history)):
-      roic_history.append(
-        (
-          net_income_history[i]
-          /
-          (stockholder_equity_history[i] + long_term_debt_history[i] - cash_history[i])
-        ) * 100
-      )
-    return roic_history
-
-  def get_roic_average(self, years):
-    history = self._get_roic_history()
-    if len(history[0:years]) < years:
-      raise AttributeError("Too few years in ROIC history")
-    return round(sum(history[0:years]) / years, 2)

--- a/src/YahooFinance.py
+++ b/src/YahooFinance.py
@@ -198,9 +198,44 @@ class YahooFinanceQuoteSummary:
     results = data.get('quoteSummary', {}).get('result', None)
     if not results:
       logging.error('Could not parse response for url: ' + self.url)
-      return
+      return False
     for module in self.modules:
       for result in results:
         if module in result:
           self.module_data[module] = result[module]
           break
+    return True
+
+  def _get_balance_sheet_history(self, position):
+    history = []
+    for stmt in self.module_data.get('balanceSheetHistory').get('balanceSheetStatements'):
+      history.append(stmt.get(position).get('raw'))
+    return history
+
+  def _get_income_statement_history(self, position):
+    history = []
+    for stmt in self.module_data.get('incomeStatementHistory').get('incomeStatementHistory'):
+      history.append(stmt.get(position).get('raw'))
+    return history
+
+  def _get_roic_history(self):
+    net_income_history = self._get_income_statement_history('netIncome')
+    cash_history = self._get_balance_sheet_history('cash')
+    long_term_debt_history = self._get_balance_sheet_history('longTermDebt')
+    stockholder_equity_history = self._get_balance_sheet_history('totalStockholderEquity')
+    roic_history = []
+    for i in range(0, len(net_income_history)):
+      roic_history.append(
+        (
+          net_income_history[i]
+          /
+          (stockholder_equity_history[i] + long_term_debt_history[i] - cash_history[i])
+        ) * 100
+      )
+    return roic_history
+
+  def get_roic_average(self, years):
+    history = self._get_roic_history()
+    if len(history[0:years]) < years:
+      raise AttributeError("Too few years in ROIC history")
+    return round(sum(history[0:years]) / years, 2)

--- a/tests/DataFetcher.py
+++ b/tests/DataFetcher.py
@@ -1,0 +1,114 @@
+"""Tests for the DataFetcher.py functions."""
+
+
+import os
+import sys
+import unittest
+
+app_path = os.path.join(os.path.dirname(__file__), "..", 'src')
+sys.path.append(app_path)
+
+from src.YahooFinance import YahooFinanceQuoteSummary, YahooFinanceQuoteSummaryModule
+from src.DataFetcher import DataFetcher
+from src.StockRow import StockRowKeyStats
+
+class DataFetcherTest(unittest.TestCase):
+
+  def test_roic_should_return_1_3_from_yahoo_and_the_rest_from_stockrow(self):
+    df = DataFetcher()
+    df.stockrow_key_stats = StockRowKeyStats('DUMMY')
+    df.stockrow_key_stats.roic_averages = [11, 22, 33, 44, 55, 66, 77]
+    modules = [
+        YahooFinanceQuoteSummaryModule.incomeStatementHistory,
+        YahooFinanceQuoteSummaryModule.balanceSheetHistory
+    ]
+    df.yahoo_finance_quote_summary = YahooFinanceQuoteSummary('DUMMY', modules)
+    df.yahoo_finance_quote_summary.module_data = {
+      'incomeStatementHistory' : {
+        'incomeStatementHistory' : [
+          {
+              'netIncome' : { 'raw' : 1 },
+          },
+          {
+              'netIncome' : { 'raw' : 2 },
+          },
+          {
+              'netIncome' : { 'raw' : 3 },
+          }
+        ]
+      },
+      'balanceSheetHistory' : {
+          'balanceSheetStatements' : [
+              {
+                  'cash' : { 'raw' : 2},
+                  'longTermDebt' : { 'raw' : 2},
+                  'totalStockholderEquity' : { 'raw' : 10 }
+              },
+              {
+                  'cash' : { 'raw' : 2},
+                  'longTermDebt' : { 'raw' : 2},
+                  'totalStockholderEquity' : { 'raw' : 10 }
+              },
+              {
+                  'cash' : { 'raw' : 2},
+                  'longTermDebt' : { 'raw' : 2},
+                  'totalStockholderEquity' : { 'raw' : 10 }
+              }
+          ]
+      }
+    }
+    roic_avgs = df.get_roic_averages()
+    self.assertEqual(roic_avgs[0], 10.0)
+    self.assertEqual(roic_avgs[1], 20.0)
+    self.assertEqual(roic_avgs[2], 33)
+    self.assertEqual(roic_avgs[3], 77)
+
+  def test_roic_should_return_1_from_yahoo_and_the_rest_from_stockrow(self):
+    df = DataFetcher()
+    df.stockrow_key_stats = StockRowKeyStats('DUMMY')
+    df.stockrow_key_stats.roic_averages = [11, 22, 33, 44, 55, 66, 77]
+    modules = [
+        YahooFinanceQuoteSummaryModule.incomeStatementHistory,
+        YahooFinanceQuoteSummaryModule.balanceSheetHistory
+    ]
+    df.yahoo_finance_quote_summary = YahooFinanceQuoteSummary('DUMMY', modules)
+    df.yahoo_finance_quote_summary.module_data = {
+      'incomeStatementHistory' : {
+        'incomeStatementHistory' : [
+          {
+              'netIncome' : { 'raw' : 1 },
+          },
+        ]
+      },
+      'balanceSheetHistory' : {
+          'balanceSheetStatements' : [
+              {
+                  'cash' : { 'raw' : 2},
+                  'longTermDebt' : { 'raw' : 2},
+                  'totalStockholderEquity' : { 'raw' : 10 }
+              },
+          ]
+      }
+    }
+    roic_avgs = df.get_roic_averages()
+    self.assertEqual(roic_avgs[0], 10.0)
+    self.assertEqual(roic_avgs[1], 22)
+    self.assertEqual(roic_avgs[2], 33)
+    self.assertEqual(roic_avgs[3], 77)
+
+  def test_roic_should_return_all_from_stockrow_if_nothing_in_yahoo(self):
+    df = DataFetcher()
+    df.stockrow_key_stats = StockRowKeyStats('DUMMY')
+    df.stockrow_key_stats.roic_averages = [11, 22, 33, 44, 55, 66, 77]
+    roic_avgs = df.get_roic_averages()
+    self.assertEqual(roic_avgs[0], 11)
+    self.assertEqual(roic_avgs[1], 22)
+    self.assertEqual(roic_avgs[2], 33)
+    self.assertEqual(roic_avgs[3], 77)
+
+  def test_roic_should_return_all_it_has_from_stockrow_if_nothing_in_yahoo(self):
+    df = DataFetcher()
+    df.stockrow_key_stats = StockRowKeyStats('DUMMY')
+    df.stockrow_key_stats.roic_averages = [11, 22]
+    roic_avgs = df.get_roic_averages()
+    self.assertEqual(len(roic_avgs), 2)

--- a/tests/RuleOneInvestingCalculationsTest.py
+++ b/tests/RuleOneInvestingCalculationsTest.py
@@ -90,3 +90,18 @@ class RuleOneInvestingCalculationsTest(unittest.TestCase):
     smaller_margin_of_safety = \
         RuleOne.calculate_margin_of_safety(100, margin_of_safety=0.25)
     self.assertEqual(smaller_margin_of_safety, 75)
+
+  def test_calculate_roic(self):
+    expected_roic_history = [
+        3.857280617164899, 0.9852216748768473, 0.199203187250996, 0.20325203252032523, 20.0
+    ]
+    net_income_history = [400, 200, 100, 50, 20]
+    cash_history = [30, 200, 300, 500, 10]
+    long_term_debt_history = [10000, 20000, 50000, 25000, 10]
+    stockholder_equity_history = [400, 500, 500, 100, 100]
+    for i in range(0, len(expected_roic_history)):
+      roic_history = RuleOne.calculate_roic(
+        net_income_history[i], cash_history[i],
+        long_term_debt_history[i], stockholder_equity_history[i]
+      )
+      self.assertEqual(expected_roic_history[i], roic_history)


### PR DESCRIPTION
This fix is for problem described in https://github.com/mrhappyasthma/IsThisStockGood/issues/63.

Please double check my reasoning on how to calculate ROIC in method `_get_roic_history` inside `YahooFinanceQuoteSummary` class.