### PR TITLE
Increase ticker length to accomodate SHELL.AS (#54).

### DIFF
--- a/templates/searchbox.html
+++ b/templates/searchbox.html
@@ -7,7 +7,7 @@
             class="form-control"
             id="ticker"
             placeholder="Ticker Symbol"
-            maxlength=5
+            maxlength=8
             onkeydown="return validateInput(event)"/>
       </div>
       <div class="col-md-1 nopadding">


### PR DESCRIPTION
With current RegEx, hyphens are *not* filtered out.

SHELL.AS is not available in MSN Money (our current main data source).

If it ever becomes available, with this source or another, this change will enable the search box to accept it and pass it on.

[x] Run the site and test, despite this change looking simple.