### PR TITLE
Use long-term debt instead of general debt (#74).

### DIFF
--- a/src/Active/MSNMoney.py
+++ b/src/Active/MSNMoney.py
@@ -78,7 +78,7 @@ class MSNMoney:
     most_recent_statement = annual_statements[max(annual_statements.keys())]
     if not most_recent_statement:
       return
-    self.total_debt = str(float(most_recent_statement.get('liabilities', 0)) * 1000000)
+    self.total_debt = str(float(most_recent_statement.get('longTermDebt', 0)))
     self.shares_outstanding = float(most_recent_statement.get('sharesOutstanding', 0))
 
     key_metrics = data.get('analysis', {}).get('keyMetrics', {})

--- a/templates/management.html
+++ b/templates/management.html
@@ -13,7 +13,7 @@
       <table class="table table-bordered text-center">
         <thead class="thead-light">
           <tr id="debt_title_labels">
-            <th>Total debt</th>
+            <th>Long term debt</th>
             <th>Free cash flow</th>
             <th>Years to pay off debt</th>
           </tr>


### PR DESCRIPTION
Adjusted the unit to match (deleted multiplication by 1 000 000).

MSFT - MSN Money value: 42 B

![msn-money](https://github.com/mrhappyasthma/IsThisStockGood/assets/17572829/8bc440cd-2ea5-47cc-84c7-24363cbc9532)

MSFT - IsThisStockGood updated value: 42 B

![isthisstockgood](https://github.com/mrhappyasthma/IsThisStockGood/assets/17572829/5f44e835-a464-44a6-9375-6606c892c617)