### PR TITLE
Divide debt to equity ratio from MSN Money by 100 before showing. (#76)

### DIFF
--- a/src/Active/MSNMoney.py
+++ b/src/Active/MSNMoney.py
@@ -161,7 +161,7 @@ class MSNMoney:
   def _parse_debt_to_equity(self, quarterly_data):
     # NOTE: ROIC is already expressed as a percentage, so just take the average over a timespan.
     debt_to_equity_ratios = _extract_data_for_key(quarterly_data, "debtToEquityRatio")
-    self.debt_equity_ratio = debt_to_equity_ratios[-1]  # Most recent quarter
+    self.debt_equity_ratio = debt_to_equity_ratios[-1] / 100  # Most recent quarter
 
 
 def _extract_data_for_key(yearly_data, key):


### PR DESCRIPTION
In MSN Money Web UI:

![debt-to-equity-msft](https://github.com/mrhappyasthma/IsThisStockGood/assets/17572829/cab0dd43-04af-4c9d-b8c4-228221d5a2fa)

Updated value in the app:

![updated-debt-to-equity-isthisstockgood](https://github.com/mrhappyasthma/IsThisStockGood/assets/17572829/81ddac8c-5150-4ade-a0d4-7a64a43a8ea4)